### PR TITLE
Fix audio being detected as video.

### DIFF
--- a/src/Detectives/ffmpegDetective.php
+++ b/src/Detectives/ffmpegDetective.php
@@ -98,7 +98,7 @@ class ffmpegDetective implements DetectiveContract
 		{
 			foreach ($this->metadata['streams'] as $streamIndex => $stream)
 			{
-				if (isset($stream['codec_type']) && $stream['codec_type'] === "video")
+				if (isset($stream['codec_type']) && $stream['codec_type'] === "video" && $stream['disposition']['attached_pic'] !== 1)
 				{
 					return $streamIndex;
 				}


### PR DESCRIPTION
ffprobe views MP3, OPUS, OGG, and FLAC as having a video stream with
dispositon:attached_pic set to 1 if they have cover art in their tag.

Filter all of these instances out of the isVideo check, so they are correctly detected as audio.